### PR TITLE
Improve Version Parsing

### DIFF
--- a/src/main/java/editor/database/version/DatabaseVersion.java
+++ b/src/main/java/editor/database/version/DatabaseVersion.java
@@ -1,0 +1,142 @@
+package editor.database.version;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class contains version information about the card database. Versions
+ * are expected to conform to major.minor.rev+YYYYMMDD, where the date
+ * represents daily minor updates (i.e. prices).
+ * 
+ * @author Alec Roelke
+ */
+public class DatabaseVersion implements Comparable<DatabaseVersion>
+{
+    /**
+     * Regular expression pattern used to match version info.
+     */
+    public static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)\\+(\\d{4}\\d{2}\\d{2})$");
+    /**
+     * Date formatter for parsing and formatting dates to strings.
+     */
+    public static final SimpleDateFormat VERSION_DATE = new SimpleDateFormat("yyyyMMdd");
+
+    /** Major version of the database. */
+    public final int major;
+    /** Minor version of the database. */
+    public final int minor;
+    /** Revision number of the database version. */
+    public final int revision;
+    /** Date of the latest minor update. */
+    public final Date date;
+
+    /**
+     * Create a new database version with a specific version number and date.
+     * 
+     * @param maj major version
+     * @param min minor version
+     * @param rev revision
+     * @param d daily update date
+     */
+    public DatabaseVersion(int maj, int min, int rev, Date d)
+    {
+        major = maj;
+        minor = min;
+        revision = rev;
+        date = d;
+    }
+
+    /**
+     * Create a new database version from the string of the form
+     * major.minor.rev+YYYYMMDD. Anything else throws an exception.
+     * 
+     * @param version string to parse
+     */
+    public DatabaseVersion(String version) throws ParseException
+    {
+        Matcher m = VERSION_PATTERN.matcher(version);
+        if (m.matches())
+        {
+            major = Integer.parseInt(m.group(1));
+            minor = Integer.parseInt(m.group(2));
+            revision = Integer.parseInt(m.group(3));
+            date = VERSION_DATE.parse(m.group(4));
+        }
+        else
+            throw new ParseException(version, 0);
+    }
+
+    /**
+     * Check if another version needs an update compared to this one based
+     * on the desired update frequency.
+     * 
+     * @param other version to check
+     * @param freq frequency of desired update
+     * @return <code>true</code> if an update is needed, and <code>false</code>
+     * otherwise.
+     */
+    public boolean needsUpdate(DatabaseVersion other, UpdateFrequency freq)
+    {
+        switch (freq)
+        {
+        case NEVER:
+            return false;
+        // The rest of the cases fall through on purpose
+        case DAILY:
+            if (!date.equals(other.date))
+                return true;
+        case REVISION:
+            if (revision != other.revision)
+                return true;
+        case MINOR:
+            if (minor != other.minor)
+                return true;
+        case MAJOR:
+            if (major != other.major)
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int compareTo(DatabaseVersion other)
+    {
+        if (major != other.major)
+            return major - other.major;
+        else if (minor != other.minor)
+            return minor - other.minor;
+        else if (revision != other.revision)
+            return revision - other.revision;
+        else
+            return date.compareTo(other.date);
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == null)
+            return false;
+        if (other == this)
+            return true;
+        if (!(other instanceof DatabaseVersion))
+            return false;
+        return compareTo((DatabaseVersion)other) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(major, minor, revision, date);
+    }
+
+    @Override
+    public String toString()
+    {
+        return List.of(major, minor, revision).stream().map(String::valueOf).reduce((a, b) -> a + "." + b).get() + "+" + VERSION_DATE.format(date);
+    }
+}

--- a/src/main/java/editor/database/version/DatabaseVersion.java
+++ b/src/main/java/editor/database/version/DatabaseVersion.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This class contains version information about the card database. Versions
@@ -137,6 +138,6 @@ public class DatabaseVersion implements Comparable<DatabaseVersion>
     @Override
     public String toString()
     {
-        return List.of(major, minor, revision).stream().map(String::valueOf).reduce((a, b) -> a + "." + b).get() + "+" + VERSION_DATE.format(date);
+        return List.of(major, minor, revision).stream().map(String::valueOf).collect(Collectors.joining(".")) + "+" + VERSION_DATE.format(date);
     }
 }

--- a/src/main/java/editor/database/version/UpdateFrequency.java
+++ b/src/main/java/editor/database/version/UpdateFrequency.java
@@ -1,0 +1,39 @@
+package editor.database.version;
+
+/**
+ * This enum specifies the frequency at which a database udpate is desired.
+ * 
+ * @author Alec Roelke
+ */
+public enum UpdateFrequency
+{
+    /** Only update on major version changes. */
+    MAJOR("Major version change"),
+    /** Update on major or minor version changes. */
+    MINOR("Minor version change"),
+    /** Update on major, minor, and revision changes. */
+    REVISION("Revision change"),
+    /** Update on all changes. */
+    DAILY("Price update (daily)"),
+    /** Don't update. */
+    NEVER("Never");
+    
+    /** String label for this UpdateFrequency. */
+    private final String label;
+
+    /**
+     * Create a new UpdateFrequency with the specified label.
+     *
+     * @param n label of the update frequency
+     */
+    UpdateFrequency(String n)
+    {
+        label = n;
+    }
+
+    @Override
+    public String toString()
+    {
+        return label;
+    }
+}

--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1525,30 +1525,23 @@ public class MainFrame extends JFrame
      */
     public int checkForUpdate(UpdateFrequency freq)
     {
-        if (!inventoryFile.exists())
+        try
         {
-            JOptionPane.showMessageDialog(this, inventoryFile.getName() + " not found.  It will be downloaded.", "Update", JOptionPane.WARNING_MESSAGE);
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(versionSite.openStream())))
+            if (!inventoryFile.exists())
             {
-                newestVersion = new DatabaseVersion(new JsonParser().parse(in.lines().collect(Collectors.joining())).getAsJsonObject().get("version").getAsString());
+                JOptionPane.showMessageDialog(this, inventoryFile.getName() + " not found.  It will be downloaded.", "Update", JOptionPane.WARNING_MESSAGE);
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(versionSite.openStream())))
+                {
+                    newestVersion = new DatabaseVersion(new JsonParser().parse(in.lines().collect(Collectors.joining())).getAsJsonObject().get("version").getAsString());
+                }
+                return UPDATE_NEEDED;
             }
-            catch (IOException e)
+            else if (SettingsDialog.settings().inventory.update != UpdateFrequency.NEVER)
             {
-                JOptionPane.showMessageDialog(this, "Error connecting to server: " + e.getMessage() + ".", "Connection Error", JOptionPane.ERROR_MESSAGE);
-                return NO_UPDATE;
-            }
-            catch (ParseException e)
-            {
-                JOptionPane.showMessageDialog(this, "Could not parse version \"" + e.getMessage() + '"', "Error", JOptionPane.ERROR_MESSAGE);
-                return NO_UPDATE;
-            }
-            return UPDATE_NEEDED;
-        }
-        else if (SettingsDialog.settings().inventory.update != UpdateFrequency.NEVER)
-        {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(versionSite.openStream())))
-            {
-                newestVersion = new DatabaseVersion(new JsonParser().parse(in.lines().collect(Collectors.joining())).getAsJsonObject().get("version").getAsString());
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(versionSite.openStream())))
+                {
+                    newestVersion = new DatabaseVersion(new JsonParser().parse(in.lines().collect(Collectors.joining())).getAsJsonObject().get("version").getAsString());
+                }
                 if (newestVersion.needsUpdate(SettingsDialog.settings().inventory.version, freq))
                 {
                     int wantUpdate = JOptionPane.showConfirmDialog(
@@ -1563,22 +1556,17 @@ public class MainFrame extends JFrame
                     );
                     return wantUpdate == JOptionPane.YES_OPTION ? UPDATE_NEEDED : UPDATE_CANCELLED;
                 }
-                else
-                    return NO_UPDATE;
-            }
-            catch (IOException e)
-            {
-                JOptionPane.showMessageDialog(this, "Error connecting to server: " + e.getMessage() + ".", "Connection Error", JOptionPane.ERROR_MESSAGE);
-                return NO_UPDATE;
-            }
-            catch (ParseException e)
-            {
-                JOptionPane.showMessageDialog(this, "Could not parse version \"" + e.getMessage() + '"', "Error", JOptionPane.ERROR_MESSAGE);
-                return NO_UPDATE;
             }
         }
-        else
-            return NO_UPDATE;
+        catch (IOException e)
+        {
+            JOptionPane.showMessageDialog(this, "Error connecting to server: " + e.getMessage() + ".", "Connection Error", JOptionPane.ERROR_MESSAGE);
+        }
+        catch (ParseException e)
+        {
+            JOptionPane.showMessageDialog(this, "Could not parse version \"" + e.getMessage() + '"', "Error", JOptionPane.ERROR_MESSAGE);
+        }
+        return NO_UPDATE;
     }
 
     /**

--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1090,7 +1090,7 @@ public class MainFrame extends JFrame
         // Inventory update item
         JMenuItem updateInventoryItem = new JMenuItem("Check for inventory update...");
         updateInventoryItem.addActionListener((e) -> {
-            switch (checkForUpdate())
+            switch (checkForUpdate(UpdateFrequency.DAILY))
             {
             case UPDATE_NEEDED:
                 if (updateInventory())
@@ -1444,7 +1444,7 @@ public class MainFrame extends JFrame
             @Override
             public void windowOpened(WindowEvent e)
             {
-                if (checkForUpdate() == UPDATE_NEEDED && updateInventory())
+                if (checkForUpdate(SettingsDialog.settings().inventory.update) == UPDATE_NEEDED && updateInventory())
                     SettingsDialog.setInventoryVersion(newestVersion);
                 loadInventory();
                 if (!inventory.isEmpty())
@@ -1517,12 +1517,13 @@ public class MainFrame extends JFrame
      * TODO: Add a timeout
      * TODO: Reduce repeated code
      *
+     * @param freq desired frequency for downloading updates
      * @return an integer value representing the state of the update.  It can be:
      * {@link #UPDATE_NEEDED}
      * {@link #NO_UPDATE}
      * {@link #UPDATE_CANCELLED}
      */
-    public int checkForUpdate()
+    public int checkForUpdate(UpdateFrequency freq)
     {
         if (!inventoryFile.exists())
         {
@@ -1548,7 +1549,7 @@ public class MainFrame extends JFrame
             try (BufferedReader in = new BufferedReader(new InputStreamReader(versionSite.openStream())))
             {
                 newestVersion = new DatabaseVersion(new JsonParser().parse(in.lines().collect(Collectors.joining())).getAsJsonObject().get("version").getAsString());
-                if (newestVersion.needsUpdate(SettingsDialog.settings().inventory.version, SettingsDialog.settings().inventory.update))
+                if (newestVersion.needsUpdate(SettingsDialog.settings().inventory.version, freq))
                 {
                     int wantUpdate = JOptionPane.showConfirmDialog(
                         this,

--- a/src/main/java/editor/gui/settings/Settings.java
+++ b/src/main/java/editor/gui/settings/Settings.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 
 import editor.collection.deck.CategorySpec;
 import editor.database.attributes.CardAttribute;
+import editor.database.version.DatabaseVersion;
+import editor.database.version.UpdateFrequency;
 
 /**
  * Structure containing global settings.  This structure consists of immutable
@@ -33,7 +35,7 @@ public final class Settings
         /** File name containing latest inventory version. */
         public final String versionFile;
         /** Version of the stored inventory. */
-        public final String version;
+        public final DatabaseVersion version;
         /** Directory to store inventory file in. */
         public final String location;
         /** Directory to store card images in. */
@@ -41,7 +43,7 @@ public final class Settings
         /** File to store tags in. */
         public final String tags;
         /** Check for inventory update on startup or don't. */
-        public final boolean update;
+        public final UpdateFrequency update;
         /** Show warnings from loading inventory. */
         public final boolean warn;
         /** Card attributes to show in inventory table. */
@@ -54,11 +56,11 @@ public final class Settings
         protected InventorySettings(String source,
                                     String file,
                                     String versionFile,
-                                    String version,
+                                    DatabaseVersion version,
                                     String location,
                                     String scans,
                                     String tags,
-                                    boolean update,
+                                    UpdateFrequency update,
                                     boolean warn,
                                     List<CardAttribute> columns,
                                     Color background,
@@ -319,7 +321,7 @@ public final class Settings
     /** Initial directory of file choosers. */
     public final String cwd;
 
-    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, String inventoryVersion, String inventoryLocation, String inventoryScans, String inventoryTags, boolean inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, String cwd)
+    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, DatabaseVersion inventoryVersion, String inventoryLocation, String inventoryScans, String inventoryTags, UpdateFrequency inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, String cwd)
     {
         this.inventory = new InventorySettings(inventorySource, inventoryFile, inventoryVersionFile, inventoryVersion, inventoryLocation, inventoryScans, inventoryTags, inventoryUpdate, inventoryWarn, inventoryColumns, inventoryBackground, inventoryStripe);
         this.editor = new EditorSettings(recentsCount, recentsFiles, explicits, presetCategories, categoryRows, editorColumns, editorStripe, handSize, handRounding, handBackground);

--- a/src/main/java/editor/gui/settings/SettingsBuilder.java
+++ b/src/main/java/editor/gui/settings/SettingsBuilder.java
@@ -12,11 +12,14 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import editor.collection.deck.CategorySpec;
 import editor.database.attributes.CardAttribute;
+import editor.database.version.DatabaseVersion;
+import editor.database.version.UpdateFrequency;
 import editor.filter.leaf.options.multi.CardTypeFilter;
 
 /**
@@ -30,11 +33,11 @@ public class SettingsBuilder
     private String inventorySource;
     private String inventoryFile;
     private String inventoryVersionFile;
-    private String inventoryVersion;
+    private DatabaseVersion inventoryVersion;
     private String inventoryLocation;
     private String inventoryScans;
     private String inventoryTags;
-    private boolean inventoryUpdate;
+    private UpdateFrequency inventoryUpdate;
     private boolean inventoryWarn;
     private List<CardAttribute> inventoryColumns;
     private Color inventoryBackground;
@@ -180,11 +183,11 @@ public class SettingsBuilder
         inventorySource = "https://mtgjson.com/json/";
         inventoryFile = "AllSets.json";
         inventoryVersionFile = "version.json";
-        inventoryVersion = "";
+        inventoryVersion = new DatabaseVersion(0, 0, 0, new Date(0));
         inventoryLocation = ".";
         inventoryScans = "scans";
         inventoryTags = "tags.json";
-        inventoryUpdate = true;
+        inventoryUpdate = UpdateFrequency.REVISION;
         inventoryWarn = true;
         inventoryColumns = List.of(NAME, MANA_COST, TYPE_LINE, EXPANSION);
         inventoryBackground = Color.WHITE;
@@ -263,7 +266,7 @@ public class SettingsBuilder
      * @return this SettingsBuilder.
      * @see Settings.InventorySettings#version
      */
-    public SettingsBuilder inventoryVersion(String version)
+    public SettingsBuilder inventoryVersion(DatabaseVersion version)
     {
         inventoryVersion = version;
         return this;
@@ -309,13 +312,13 @@ public class SettingsBuilder
     }
 
     /**
-     * Change whether or not to automatically check for updates on startup.
+     * Change how often new updates should be dowloaded.
      * 
-     * @param update whether or not to check for updates
+     * @param update how often to download new updates
      * @return this SettingsBuilder
      * @see Settings.InventorySettings#update
      */
-    public SettingsBuilder inventoryUpdate(boolean update)
+    public SettingsBuilder inventoryUpdate(UpdateFrequency update)
     {
         inventoryUpdate = update;
         return this;

--- a/src/main/java/editor/gui/settings/SettingsDialog.java
+++ b/src/main/java/editor/gui/settings/SettingsDialog.java
@@ -29,6 +29,7 @@ import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JColorChooser;
+import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
@@ -51,6 +52,8 @@ import javax.swing.tree.TreeSelectionModel;
 import editor.collection.deck.CategorySpec;
 import editor.database.attributes.CardAttribute;
 import editor.database.card.Card;
+import editor.database.version.DatabaseVersion;
+import editor.database.version.UpdateFrequency;
 import editor.gui.MainFrame;
 import editor.gui.display.CardTable;
 import editor.gui.display.CategoryList;
@@ -229,7 +232,7 @@ public class SettingsDialog extends JDialog
      * 
      * @param version new version of the inventory
      */
-    public static void setInventoryVersion(String version)
+    public static void setInventoryVersion(DatabaseVersion version)
     {
         settings = new SettingsBuilder(settings).inventoryVersion(version).build();
     }
@@ -308,9 +311,9 @@ public class SettingsDialog extends JDialog
      */
     private JCheckBox suppressCheckBox;
     /**
-     * Check box indicating whether or not to perform a check for updates on program start.
+     * Combo box indicating how often to download updates.
      */
-    private JCheckBox updateCheckBox;
+    private JComboBox<UpdateFrequency> updateBox;
 
     /**
      * Create a new SettingsDialog.
@@ -434,8 +437,12 @@ public class SettingsDialog extends JDialog
 
         // Check for update on startup
         JPanel updatePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        updateCheckBox = new JCheckBox("Check for update on program start", settings.inventory.update);
-        updatePanel.add(updateCheckBox);
+        JLabel updateLabel = new JLabel("Update inventory on:");
+        updatePanel.add(updateLabel);
+        updatePanel.add(Box.createHorizontalStrut(5));
+        updateBox = new JComboBox<>(UpdateFrequency.values());
+        updateBox.setSelectedIndex(settings.inventory.update.ordinal());
+        updatePanel.add(updateBox);
         updatePanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, updatePanel.getPreferredSize().height));
         inventoryPanel.add(updatePanel);
 
@@ -726,7 +733,7 @@ public class SettingsDialog extends JDialog
                 .inventorySource(inventorySiteField.getText())
                 .inventoryFile(inventoryFileField.getText())
                 .inventoryLocation(inventoryDirField.getText())
-                .inventoryUpdate(updateCheckBox.isSelected())
+                .inventoryUpdate(updateBox.getItemAt(updateBox.getSelectedIndex()))
                 .inventoryWarn(suppressCheckBox.isSelected())
                 .inventoryColumns(inventoryColumnCheckBoxes.stream().filter(JCheckBox::isSelected).map((c) -> CardAttribute.fromString(c.getText())).collect(Collectors.toList()))
                 .inventoryStripe(inventoryStripeColor.getColor())

--- a/src/main/java/editor/serialization/VersionAdapter.java
+++ b/src/main/java/editor/serialization/VersionAdapter.java
@@ -1,0 +1,36 @@
+package editor.serialization;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import editor.database.version.DatabaseVersion;
+
+public class VersionAdapter implements JsonSerializer<DatabaseVersion>, JsonDeserializer<DatabaseVersion>
+{
+    @Override
+    public JsonElement serialize(DatabaseVersion src, Type typeOfSrc, JsonSerializationContext context)
+    {
+        return new JsonPrimitive(src.toString());
+    }
+
+    @Override
+    public DatabaseVersion deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    {
+        try
+        {
+            return new DatabaseVersion(json.getAsString());
+        }
+        catch (ParseException e)
+        {
+            throw new JsonParseException(e);
+        }
+    }
+}


### PR DESCRIPTION
Addressing #63, rather than just comparing strings, parse the version into a class and use that class to determine if an update is needed. For the user, this allows them to indicate if they want to update the database only when major version changes are made down to every time the version changes (typically every day), or even never.