### PR TITLE
Dynamically Disable Menus

### DIFF
--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1283,10 +1283,11 @@ public class MainFrame extends JFrame
 
         // Add the card to the main deck
         CardMenuItems oracleMenuCardItems = new CardMenuItems(() -> selectedFrame, () -> Arrays.asList(selectedCards.get(0)), true);
+        JSeparator[] oracleMenuCardSeparators = new JSeparator[] { new JSeparator(), new JSeparator() };
         oracleMenuCardItems.addAddItems(oraclePopupMenu);
-        oraclePopupMenu.add(new JSeparator());
+        oraclePopupMenu.add(oracleMenuCardSeparators[0]);
         oracleMenuCardItems.addRemoveItems(oraclePopupMenu);
-        oraclePopupMenu.add(new JSeparator());
+        oraclePopupMenu.add(oracleMenuCardSeparators[1]);
 
         // Add the card to the sideboard
         CardMenuItems oracleMenuSBCardItems = new CardMenuItems(() -> selectedFrame, () -> Arrays.asList(selectedCards.get(0)), false);
@@ -1298,7 +1299,8 @@ public class MainFrame extends JFrame
         oraclePopupMenu.add(oracleMenuSBCardItems.removeSingle());
         oracleMenuSBCardItems.removeAll().setText("Remove All from Sideboard");
         oraclePopupMenu.add(oracleMenuSBCardItems.removeAll());
-        oraclePopupMenu.add(new JSeparator());
+        JSeparator oracleMenuSBSeparator = new JSeparator();
+        oraclePopupMenu.add(oracleMenuSBSeparator);
 
         JMenuItem oracleEditTagsItem = new JMenuItem("Edit Tags...");
         oracleEditTagsItem.addActionListener((e) -> CardTagPanel.editTags(getSelectedCards(), this));
@@ -1307,7 +1309,10 @@ public class MainFrame extends JFrame
         // Popup listener for oracle popup menu
         oraclePopupMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
             oracleMenuCardItems.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
+            for (JSeparator sep : oracleMenuCardSeparators)
+                sep.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
             oracleMenuSBCardItems.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
+            oracleMenuSBSeparator.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
             oracleEditTagsItem.setVisible(!selectedCards.isEmpty());
         }));
 
@@ -1375,10 +1380,11 @@ public class MainFrame extends JFrame
 
         // Add cards to the main deck
         CardMenuItems inventoryMenuCardItems = new CardMenuItems(() -> selectedFrame, this::getSelectedCards, true);
+        JSeparator[] inventoryMenuCardSeparators = new JSeparator[] { new JSeparator(), new JSeparator() };
         inventoryMenuCardItems.addAddItems(inventoryMenu);
-        inventoryMenu.add(new JSeparator());
+        inventoryMenu.add(inventoryMenuCardSeparators[0]);
         inventoryMenuCardItems.addRemoveItems(inventoryMenu);
-        inventoryMenu.add(new JSeparator());
+        inventoryMenu.add(inventoryMenuCardSeparators[1]);
 
         // Add cards to the sideboard
         CardMenuItems inventoryMenuSBItems = new CardMenuItems(() -> selectedFrame, this::getSelectedCards, false);
@@ -1390,7 +1396,8 @@ public class MainFrame extends JFrame
         inventoryMenu.add(inventoryMenuSBItems.removeSingle());
         inventoryMenuSBItems.removeAll().setText("Remove All from Sideboard");
         inventoryMenu.add(inventoryMenuSBItems.removeAll());
-        inventoryMenu.add(new JSeparator());
+        JSeparator inventoryMenuSBSeparator = new JSeparator();
+        inventoryMenu.add(inventoryMenuSBSeparator);
 
         // Edit tags item
         JMenuItem editTagsItem = new JMenuItem("Edit Tags...");
@@ -1400,7 +1407,10 @@ public class MainFrame extends JFrame
         // Inventory menu listener
         inventoryMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
             inventoryMenuCardItems.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
+            for (JSeparator sep : inventoryMenuCardSeparators)
+                sep.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
             inventoryMenuSBItems.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
+            inventoryMenuSBSeparator.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
             editTagsItem.setEnabled(!selectedCards.isEmpty());
         }));
 

--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1306,11 +1306,9 @@ public class MainFrame extends JFrame
 
         // Popup listener for oracle popup menu
         oraclePopupMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
-            for (JMenuItem item : oracleMenuCardItems)
-                item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
-            for (JMenuItem item : oracleMenuSBCardItems)
-                item.setEnabled(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
-            oracleEditTagsItem.setEnabled(!selectedCards.isEmpty());
+            oracleMenuCardItems.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
+            oracleMenuSBCardItems.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
+            oracleEditTagsItem.setVisible(!selectedCards.isEmpty());
         }));
 
         // Panel containing inventory and image of currently-selected card
@@ -1401,10 +1399,8 @@ public class MainFrame extends JFrame
 
         // Inventory menu listener
         inventoryMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
-            for (JMenuItem item : inventoryMenuCardItems)
-                item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
-            for (JMenuItem item : inventoryMenuSBItems)
-                item.setEnabled(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
+            inventoryMenuCardItems.setVisible(selectedFrame.isPresent() && !selectedCards.isEmpty());
+            inventoryMenuSBItems.setVisible(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
             editTagsItem.setEnabled(!selectedCards.isEmpty());
         }));
 

--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1309,7 +1309,7 @@ public class MainFrame extends JFrame
             for (JMenuItem item : oracleMenuCardItems)
                 item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
             for (JMenuItem item : oracleMenuSBCardItems)
-                item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
+                item.setEnabled(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
             oracleEditTagsItem.setEnabled(!selectedCards.isEmpty());
         }));
 
@@ -1404,7 +1404,7 @@ public class MainFrame extends JFrame
             for (JMenuItem item : inventoryMenuCardItems)
                 item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
             for (JMenuItem item : inventoryMenuSBItems)
-                item.setEnabled(selectedFrame.isPresent() && !selectedCards.isEmpty());
+                item.setEnabled(selectedFrame.map((f) -> !f.getExtraNames().isEmpty()).orElse(false) && !selectedCards.isEmpty());
             editTagsItem.setEnabled(!selectedCards.isEmpty());
         }));
 

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -771,7 +771,8 @@ public class EditorFrame extends JInternalFrame
         // Move cards to sideboard
         tableMenu.add(moveToMenu = new JMenu("Move to"));
         tableMenu.add(moveAllToMenu = new JMenu("Move all to"));
-        tableMenu.add(new JSeparator());
+        JSeparator moveSeparator = new JSeparator();
+        tableMenu.add(moveSeparator);
 
         // Quick edit categories
         JMenu addToCategoryMenu = new JMenu("Include in");
@@ -802,8 +803,9 @@ public class EditorFrame extends JInternalFrame
         tableMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
             for (JMenuItem item : tableMenuCardItems)
                 item.setEnabled(!parent.getSelectedCards().isEmpty());
-            moveToMenu.setEnabled(!extras.isEmpty());
-            moveAllToMenu.setEnabled(!extras.isEmpty());
+            moveToMenu.setVisible(!extras.isEmpty());
+            moveAllToMenu.setVisible(!extras.isEmpty());
+            moveSeparator.setVisible(!extras.isEmpty());
             addToCategoryMenu.setEnabled(!categoryPanels.isEmpty());
             removeFromCategoryMenu.setEnabled(!categoryPanels.isEmpty());
             editCategoriesItem.setEnabled(!categoryPanels.isEmpty());
@@ -1383,7 +1385,6 @@ public class EditorFrame extends JInternalFrame
                 editCategoriesItem, categoriesSeparator, newCategory.table));
         tableMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
             removeFromCategoryItem.setText("Exclude from " + newCategory.getCategoryName());
-
             for (JMenuItem item : tableMenuCardItems)
                 item.setEnabled(!parent.getSelectedCards().isEmpty());
                 editTagsItem.setEnabled(!parent.getSelectedCards().isEmpty());

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -801,8 +801,7 @@ public class EditorFrame extends JInternalFrame
         tableMenu.addPopupMenuListener(new TableCategoriesPopupListener(addToCategoryMenu, removeFromCategoryMenu,
                 editCategoriesItem, categoriesSeparator, deck.table));
         tableMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
-            for (JMenuItem item : tableMenuCardItems)
-                item.setEnabled(!parent.getSelectedCards().isEmpty());
+            tableMenuCardItems.setEnabled(!parent.getSelectedCards().isEmpty());
             moveToMenu.setVisible(!extras.isEmpty());
             moveAllToMenu.setVisible(!extras.isEmpty());
             moveSeparator.setVisible(!extras.isEmpty());
@@ -1385,9 +1384,8 @@ public class EditorFrame extends JInternalFrame
                 editCategoriesItem, categoriesSeparator, newCategory.table));
         tableMenu.addPopupMenuListener(PopupMenuListenerFactory.createVisibleListener((e) -> {
             removeFromCategoryItem.setText("Exclude from " + newCategory.getCategoryName());
-            for (JMenuItem item : tableMenuCardItems)
-                item.setEnabled(!parent.getSelectedCards().isEmpty());
-                editTagsItem.setEnabled(!parent.getSelectedCards().isEmpty());
+            tableMenuCardItems.setEnabled(!parent.getSelectedCards().isEmpty());
+            editTagsItem.setEnabled(!parent.getSelectedCards().isEmpty());
         }));
 
         

--- a/src/main/java/editor/gui/generic/CardMenuItems.java
+++ b/src/main/java/editor/gui/generic/CardMenuItems.java
@@ -177,4 +177,26 @@ public class CardMenuItems implements Iterable<JMenuItem>
     {
         return items[3];
     }
+
+    /**
+     * Convenience method for enabling or disabling all menu items at once.
+     * 
+     * @param en whether items should be enabled or not
+     */
+    public void setEnabled(boolean en)
+    {
+        for (JMenuItem item : items)
+            item.setEnabled(en);
+    }
+
+    /**
+     * Convenience method for controlling all items' visibilities.
+     * 
+     * @param visible whether items should be visible or not
+     */
+    public void setVisible(boolean visible)
+    {
+        for (JMenuItem item : items)
+            item.setVisible(visible);
+    }
 }


### PR DESCRIPTION
If menu items in popup menus are not available because a deck is not open or there are no extra lists, make them not visible rather than disabling them.  Addresses #43.