### PR TITLE
Use Integer ID instead of name

### DIFF
--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -192,7 +192,7 @@ public class MainFrame extends JFrame
         {
             Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             Card card = inventory.get(table.convertRowIndexToModel(row));
-            boolean main = selectedFrame.map((f) -> f.hasCard("", card)).orElse(false);
+            boolean main = selectedFrame.map((f) -> f.hasCard(EditorFrame.MAIN_DECK, card)).orElse(false);
             boolean extra = selectedFrame.map((f) -> f.getExtraCards().contains(card)).orElse(false);
             if (main && extra)
                 ComponentUtils.changeFontRecursive(c, c.getFont().deriveFont(Font.BOLD | Font.ITALIC));
@@ -1349,7 +1349,7 @@ public class MainFrame extends JFrame
         inventoryTable.setStripeColor(SettingsDialog.settings().inventory.stripe);
         inventoryTable.addMouseListener(MouseListenerFactory.createClickListener((e) -> selectedFrame.ifPresent((f) -> {
             if (e.getClickCount() % 2 == 0)
-                f.addCards("", getSelectedCards(), 1);
+                f.addCards(EditorFrame.MAIN_DECK, getSelectedCards(), 1);
         })));
         inventoryTable.setTransferHandler(new TransferHandler()
         {

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1477,10 +1477,12 @@ public class EditorFrame extends JInternalFrame
             throw new IllegalArgumentException("only the main deck can have ID 0");
         else if (lists.size() > id && lists.get(id) != null)
             throw new IllegalArgumentException("extra already exists at ID " + id);
-        else if (extras().stream().anyMatch((l) -> l.name.get().equals(name)))
-            throw new IllegalArgumentException("sideboard \"" + name + "\" already exists");
         else
         {
+            var extras = extras();
+            if (extras.stream().anyMatch((l) -> l.name.get().equals(name)))
+                throw new IllegalArgumentException("sideboard \"" + name + "\" already exists");
+
             DeckData newExtra = new DeckData(name);
             while (lists.size() <= id)
                 lists.add(null);
@@ -1492,8 +1494,8 @@ public class EditorFrame extends JInternalFrame
             extrasPane.setSelectedIndex(index);
             extrasPane.getTabComponentAt(extrasPane.getSelectedIndex()).requestFocus();
 
-            extrasPanel.setVisible(!extras().isEmpty());
-            emptyPanel.setVisible(extras().isEmpty());
+            extrasPanel.setVisible(!extras.isEmpty());
+            emptyPanel.setVisible(extras.isEmpty());
 
             panel.addActionListener((e) -> {
                 switch (e.getActionCommand())
@@ -1994,7 +1996,10 @@ public class EditorFrame extends JInternalFrame
      */
     public boolean hasCard(int id, Card card)
     {
-        return getList(id).contains(card);
+        if (lists.get(id) == null)
+            throw new ArrayIndexOutOfBoundsException(id);
+        else
+            return lists.get(id).current.contains(card);
     }
 
     /**

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1894,7 +1894,7 @@ public class EditorFrame extends JInternalFrame
     /**
      * Get the card at the given index in the given table.
      *
-     * @param t     table to get the card from
+     * @param t table to get the card from
      * @param index index into the given table to get a card from
      * @return the card in the deck at the given index in the given table, if the table is in this EditorFrame.
      */

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1950,6 +1950,9 @@ public class EditorFrame extends JInternalFrame
         return IntStream.range(0, lists.size()).filter((i) -> lists.get(i) != null).toArray();
     }
 
+    /**
+     * @return The ID of the extra list corresponding to the selected tab.
+     */
     public Optional<Integer> getSelectedExtraID()
     {
         for (int i = 0; i < lists.size(); i++)

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1515,7 +1515,7 @@ public class EditorFrame extends JInternalFrame
                     final String old = panel.getOldTitle();
                     if (current.isEmpty())
                         panel.setTitle(old);
-                    else if (extras().stream().anyMatch((l) -> l.name.get().equals(name)))
+                    else if (extras().stream().anyMatch((l) -> l.name.get().equals(current)))
                     {
                         panel.setTitle(old);
                         JOptionPane.showMessageDialog(EditorFrame.this, "Sideboard \"" + current + "\" already exists.", "Error", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1479,8 +1479,7 @@ public class EditorFrame extends JInternalFrame
             throw new IllegalArgumentException("extra already exists at ID " + id);
         else
         {
-            var extras = extras();
-            if (extras.stream().anyMatch((l) -> l.name.get().equals(name)))
+            if (extras().stream().anyMatch((l) -> l.name.get().equals(name)))
                 throw new IllegalArgumentException("sideboard \"" + name + "\" already exists");
 
             DeckData newExtra = new DeckData(name);
@@ -1494,8 +1493,8 @@ public class EditorFrame extends JInternalFrame
             extrasPane.setSelectedIndex(index);
             extrasPane.getTabComponentAt(extrasPane.getSelectedIndex()).requestFocus();
 
-            extrasPanel.setVisible(!extras.isEmpty());
-            emptyPanel.setVisible(extras.isEmpty());
+            extrasPanel.setVisible(!extras().isEmpty());
+            emptyPanel.setVisible(extras().isEmpty());
 
             panel.addActionListener((e) -> {
                 switch (e.getActionCommand())

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1513,10 +1513,8 @@ public class EditorFrame extends JInternalFrame
                         assert(lists.get(id) == null);
                         lists.set(id, lists.get(tmp));
                         lists.remove(tmp);
-                        if (!lists.get(id).current.addAll(extra.current))
-                            tmp = -1;
-                        if (!lists.get(id).original.addAll(extra.original))
-                            tmp = -1;
+                        lists.get(id).current.addAll(extra.current);
+                        lists.get(id).original.addAll(extra.original);
                         return tmp > 0;
                     });
                     break;

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -253,12 +253,26 @@ public class EditorFrame extends JInternalFrame
         }
 
         /**
-         * Create a new, empty DeckData representing the main deck. Do not use this
-         * constructor to create an extra list.
+         * Create a new DeckData using the given Deck.  The original deck
+         * will be a copy of it. Do not use this constructor for the main deck.
+         * 
+         * @param deck Deck to use as backing data
+         * @param n name of the deck
          */
-        public DeckData()
+        public DeckData(Deck deck, String n)
         {
-            this(new Deck());
+            this(deck, Optional.of(n));
+        }
+
+        /**
+         * Create a new DeckData for a list with the given name. Do not use this
+         * constructor for the main deck.
+         * 
+         * @param n name of the new list
+         */
+        public DeckData(String n)
+        {
+            this(new Deck(), n);
         }
 
         /**
@@ -1474,7 +1488,7 @@ public class EditorFrame extends JInternalFrame
             throw new IllegalArgumentException("sideboard \"" + name + "\" already exists");
         else
         {
-            DeckData newExtra = new DeckData();
+            DeckData newExtra = new DeckData(name);
             lists.add(newExtra);
             final int id = lists.size() - 1;
 

--- a/src/main/java/editor/gui/generic/CardMenuItems.java
+++ b/src/main/java/editor/gui/generic/CardMenuItems.java
@@ -46,9 +46,9 @@ public class CardMenuItems implements Iterable<JMenuItem>
      */
     public CardMenuItems(final Supplier<Optional<EditorFrame>> monitor, final Supplier<? extends Collection<Card>> cards, final boolean main)
     {
-        final Function<EditorFrame, Optional<String>> name = (f) -> main ? Optional.of("") : f.getSelectedExtraName();
-        final IntConsumer addN = (i) -> monitor.get().ifPresent((f) -> name.apply(f).ifPresent((n) -> f.addCards(n, cards.get(), i)));
-        final Runnable fillPlayset = () -> monitor.get().ifPresent((f) -> name.apply(f).ifPresent((n) -> {
+        final Function<EditorFrame, Optional<Integer>> id = (f) -> main ? Optional.of(EditorFrame.MAIN_DECK) : f.getSelectedExtraID();
+        final IntConsumer addN = (i) -> monitor.get().ifPresent((f) -> id.apply(f).ifPresent((n) -> f.addCards(n, cards.get(), i)));
+        final Runnable fillPlayset = () -> monitor.get().ifPresent((f) -> id.apply(f).ifPresent((n) -> {
             f.modifyCards(n, cards.get().stream().collect(Collectors.toMap(Function.identity(), (c) -> {
                 if (f.hasCard(n, c))
                     return Math.max(0, SettingsDialog.PLAYSET_SIZE - f.getList(n).getEntry(c).count());
@@ -57,7 +57,7 @@ public class CardMenuItems implements Iterable<JMenuItem>
             })));
         }));
         final IntConsumer removeN = (i) -> {
-            monitor.get().ifPresent((f) -> name.apply(f).ifPresent((n) -> f.removeCards(n, cards.get(), i)));
+            monitor.get().ifPresent((f) -> id.apply(f).ifPresent((n) -> f.removeCards(n, cards.get(), i)));
         };
         items = new JMenuItem[6];
 

--- a/src/main/java/editor/util/UndoableAction.java
+++ b/src/main/java/editor/util/UndoableAction.java
@@ -11,27 +11,24 @@ import java.util.function.Supplier;
  * @param <U> information to be returned by the undone action
  * @author Alec Roelke
  */
-public class UndoableAction<R, U>
+public interface UndoableAction<R, U>
 {
     /**
-     * "Forward" action that represents what was done.
-     */
-    private final Supplier<R> forward;
-    /**
-     * "Reverse" action that represents how to undo the forward action.
-     */
-    private final Supplier<U> reverse;
-
-    /**
-     * Create a new UndoableAction.
+     * Create a new undoable action from the given functions.
      * 
-     * @param f "forward" action representing what was done
-     * @param r "reverse" action representing how to undo it
+     * @param <R> return type of the forward action
+     * @param <U> return type of the reverse action
+     * @param forward forward action to perform
+     * @param reverse reverse action to perform
+     * @return The new UndoableAction.
      */
-    public UndoableAction(final Supplier<R> f, final Supplier<U> r)
+    public static <R, U> UndoableAction<R, U> createAction(Supplier<R> forward, Supplier<U> reverse)
     {
-        forward = f;
-        reverse = r;
+        return new UndoableAction<>()
+        {
+            public R redo() { return forward.get(); }
+            public U undo() { return reverse.get(); }
+        };
     }
 
     /**
@@ -40,18 +37,12 @@ public class UndoableAction<R, U>
      * @return a value containing information about the result of performing
      * the action.
      */
-    public R redo()
-    {
-        return forward.get();
-    }
+    R redo();
 
     /**
      * Undo the action.
      * 
      * @return a value containing information about the result undoing the action.
      */
-    public U undo()
-    {
-        return reverse.get();
-    }
+    U undo();
 }

--- a/src/main/java/editor/util/UndoableAction.java
+++ b/src/main/java/editor/util/UndoableAction.java
@@ -26,7 +26,9 @@ public interface UndoableAction<R, U>
     {
         return new UndoableAction<>()
         {
+            @Override
             public R redo() { return forward.get(); }
+            @Override
             public U undo() { return reverse.get(); }
         };
     }


### PR DESCRIPTION
Since extra names can change, using their names as the keys to their lists is brittle. Instead, it's better to create a permanent ID that never changes, even after deleting it.  This way, if it's restored via undo or redo, references to it are still valid.