### PR TITLE
Selection Preservation

### DIFF
--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -732,7 +732,16 @@ public class EditorFrame extends JInternalFrame
                 {
                     final int id = i;
                     JMenuItem moveToItem = new JMenuItem(lists.get(i).name.get());
-                    moveToItem.addActionListener((e2) -> moveCards(MAIN_DECK, id, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))));
+                    moveToItem.addActionListener((e2) -> {
+                        var selected = parent.getSelectedCards();
+                        boolean preserve = selected.stream().allMatch((c) -> deck().current.getEntry(c).count() == 1);
+                        if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
+                        {
+                            parent.setSelectedComponents(lists.get(id).table, lists.get(id).current);
+                            updateTables(selected);
+                            lists.get(id).table.scrollRectToVisible(lists.get(id).table.getCellRect(lists.get(id).table.getSelectedRow(), 0, true));
+                        }
+                    });
                     moveToMenu.add(moveToItem);
                     JMenuItem moveAllToItem = new JMenuItem(lists.get(i).name.get());
                     moveAllToItem.addActionListener((e2) -> {
@@ -1990,10 +1999,27 @@ public class EditorFrame extends JInternalFrame
 
         // Move cards to main deck
         JMenuItem moveToMainItem = new JMenuItem("Move to Main Deck");
-        moveToMainItem.addActionListener((e) -> moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))));
+        moveToMainItem.addActionListener((e) -> {
+            var selected = parent.getSelectedCards();
+            boolean preserve = selected.stream().allMatch((c) -> lists.get(id).current.getEntry(c).count() == 1);
+            if (moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
+            {
+                parent.setSelectedComponents(deck().table, deck().current);
+                updateTables(selected);
+                deck().table.scrollRectToVisible(deck().table.getCellRect(deck().table.getSelectedRow(), 0, true));
+            }
+        });
         extraMenu.add(moveToMainItem);
         JMenuItem moveAllToMainItem = new JMenuItem("Move All to Main Deck");
-        moveAllToMainItem.addActionListener((e) -> moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> lists.get(id).current.getEntry(c).count()))));
+        moveAllToMainItem.addActionListener((e) -> {
+            var selected = parent.getSelectedCards();
+            if (moveCards(id, MAIN_DECK, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> lists.get(id).current.getEntry(c).count()))))
+            {
+                parent.setSelectedComponents(deck().table, deck().current);
+                updateTables(selected);
+                deck().table.scrollRectToVisible(deck().table.getCellRect(deck().table.getSelectedRow(), 0, true));
+            }
+        });
         extraMenu.add(moveAllToMainItem);
         extraMenu.add(new JSeparator());
 

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -732,19 +732,10 @@ public class EditorFrame extends JInternalFrame
                 {
                     final int id = i;
                     JMenuItem moveToItem = new JMenuItem(lists.get(i).name.get());
-                    moveToItem.addActionListener((e2) -> {
-                        var selected = parent.getSelectedCards();
-                        boolean preserve = selected.stream().allMatch((c) -> deck().current.getEntry(c).count() == 1);
-                        if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
-                            preserveSelection(selected, lists.get(id));
-                    });
+                    moveToItem.addActionListener((e2) -> moveCards(MAIN_DECK, id, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))));
                     moveToMenu.add(moveToItem);
                     JMenuItem moveAllToItem = new JMenuItem(lists.get(i).name.get());
-                    moveAllToItem.addActionListener((e2) -> {
-                        var selected = parent.getSelectedCards();
-                        if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> deck().current.getEntry(c).count()))))
-                            preserveSelection(selected, lists.get(id));
-                    });
+                    moveAllToItem.addActionListener((e2) -> moveCards(MAIN_DECK, id, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> deck().current.getEntry(c).count()))));
                     moveAllToMenu.add(moveAllToItem);
                 }
             }
@@ -1991,19 +1982,10 @@ public class EditorFrame extends JInternalFrame
 
         // Move cards to main deck
         JMenuItem moveToMainItem = new JMenuItem("Move to Main Deck");
-        moveToMainItem.addActionListener((e) -> {
-            var selected = parent.getSelectedCards();
-            boolean preserve = selected.stream().allMatch((c) -> lists.get(id).current.getEntry(c).count() == 1);
-            if (moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
-                preserveSelection(selected, deck());
-        });
+        moveToMainItem.addActionListener((e) -> moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))));
         extraMenu.add(moveToMainItem);
         JMenuItem moveAllToMainItem = new JMenuItem("Move All to Main Deck");
-        moveAllToMainItem.addActionListener((e) -> {
-            var selected = parent.getSelectedCards();
-            if (moveCards(id, MAIN_DECK, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> lists.get(id).current.getEntry(c).count()))))
-                preserveSelection(selected, deck());
-        });
+        moveAllToMainItem.addActionListener((e) -> moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> lists.get(id).current.getEntry(c).count()))));
         extraMenu.add(moveAllToMainItem);
         extraMenu.add(new JSeparator());
 
@@ -2230,19 +2212,6 @@ public class EditorFrame extends JInternalFrame
                 throw new RuntimeException("error redoing action");
         }
         return false;
-    }
-
-    /**
-     * Set the selection in the target table.  To be used after moving cards between lists.
-     *
-     * @param selected selected cards
-     * @param target table/list to update
-     */
-    private void preserveSelection(Collection<? extends Card> selected, DeckData target)
-    {
-        parent.setSelectedComponents(target.table, target.current);
-        updateTables(selected);
-        target.table.scrollRectToVisible(target.table.getCellRect(target.table.getSelectedRow(), 0, true));
     }
 
     /**
@@ -2473,7 +2442,7 @@ public class EditorFrame extends JInternalFrame
      * 
      * @param selected list of selected cards from <b>before</b> the change to the deck was made
      */
-    private void updateTables(Collection<? extends Card> selected)
+    private void updateTables(Collection<Card> selected)
     {
         updateStats();
         parent.updateCardsInDeck();

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -735,7 +735,15 @@ public class EditorFrame extends JInternalFrame
                     moveToItem.addActionListener((e2) -> moveCards(MAIN_DECK, id, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))));
                     moveToMenu.add(moveToItem);
                     JMenuItem moveAllToItem = new JMenuItem(lists.get(i).name.get());
-                    moveAllToItem.addActionListener((e2) -> moveCards(MAIN_DECK, id, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> deck().current.getEntry(c).count()))));
+                    moveAllToItem.addActionListener((e2) -> {
+                        var selected = parent.getSelectedCards();
+                        if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> deck().current.getEntry(c).count()))))
+                        {
+                            parent.setSelectedComponents(lists.get(id).table, lists.get(id).current);
+                            updateTables(selected);
+                            lists.get(id).table.scrollRectToVisible(lists.get(id).table.getCellRect(lists.get(id).table.getSelectedRow(), 0, true));
+                        }
+                    });
                     moveAllToMenu.add(moveAllToItem);
                 }
             }

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -736,22 +736,14 @@ public class EditorFrame extends JInternalFrame
                         var selected = parent.getSelectedCards();
                         boolean preserve = selected.stream().allMatch((c) -> deck().current.getEntry(c).count() == 1);
                         if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
-                        {
-                            parent.setSelectedComponents(lists.get(id).table, lists.get(id).current);
-                            updateTables(selected);
-                            lists.get(id).table.scrollRectToVisible(lists.get(id).table.getCellRect(lists.get(id).table.getSelectedRow(), 0, true));
-                        }
+                            preserveSelection(selected, lists.get(id));
                     });
                     moveToMenu.add(moveToItem);
                     JMenuItem moveAllToItem = new JMenuItem(lists.get(i).name.get());
                     moveAllToItem.addActionListener((e2) -> {
                         var selected = parent.getSelectedCards();
                         if (moveCards(MAIN_DECK, id, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> deck().current.getEntry(c).count()))))
-                        {
-                            parent.setSelectedComponents(lists.get(id).table, lists.get(id).current);
-                            updateTables(selected);
-                            lists.get(id).table.scrollRectToVisible(lists.get(id).table.getCellRect(lists.get(id).table.getSelectedRow(), 0, true));
-                        }
+                            preserveSelection(selected, lists.get(id));
                     });
                     moveAllToMenu.add(moveAllToItem);
                 }
@@ -2003,22 +1995,14 @@ public class EditorFrame extends JInternalFrame
             var selected = parent.getSelectedCards();
             boolean preserve = selected.stream().allMatch((c) -> lists.get(id).current.getEntry(c).count() == 1);
             if (moveCards(id, MAIN_DECK, parent.getSelectedCards().stream().collect(Collectors.toMap(Function.identity(), (c) -> 1))) && preserve)
-            {
-                parent.setSelectedComponents(deck().table, deck().current);
-                updateTables(selected);
-                deck().table.scrollRectToVisible(deck().table.getCellRect(deck().table.getSelectedRow(), 0, true));
-            }
+                preserveSelection(selected, deck());
         });
         extraMenu.add(moveToMainItem);
         JMenuItem moveAllToMainItem = new JMenuItem("Move All to Main Deck");
         moveAllToMainItem.addActionListener((e) -> {
             var selected = parent.getSelectedCards();
             if (moveCards(id, MAIN_DECK, selected.stream().collect(Collectors.toMap(Function.identity(), (c) -> lists.get(id).current.getEntry(c).count()))))
-            {
-                parent.setSelectedComponents(deck().table, deck().current);
-                updateTables(selected);
-                deck().table.scrollRectToVisible(deck().table.getCellRect(deck().table.getSelectedRow(), 0, true));
-            }
+                preserveSelection(selected, deck());
         });
         extraMenu.add(moveAllToMainItem);
         extraMenu.add(new JSeparator());
@@ -2249,6 +2233,19 @@ public class EditorFrame extends JInternalFrame
     }
 
     /**
+     * Set the selection in the target table.  To be used after moving cards between lists.
+     *
+     * @param selected selected cards
+     * @param target table/list to update
+     */
+    private void preserveSelection(Collection<? extends Card> selected, DeckData target)
+    {
+        parent.setSelectedComponents(target.table, target.current);
+        updateTables(selected);
+        target.table.scrollRectToVisible(target.table.getCellRect(target.table.getSelectedRow(), 0, true));
+    }
+
+    /**
      * Remove some copies of each of a collection of cards from the specified list.
      * 
      * @param id ID of the list to remove cards from
@@ -2476,7 +2473,7 @@ public class EditorFrame extends JInternalFrame
      * 
      * @param selected list of selected cards from <b>before</b> the change to the deck was made
      */
-    private void updateTables(Collection<Card> selected)
+    private void updateTables(Collection<? extends Card> selected)
     {
         updateStats();
         parent.updateCardsInDeck();

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -2137,19 +2137,31 @@ public class EditorFrame extends JInternalFrame
 
         return performAction(() -> {
             var selected = parent.getSelectedCards();
+            boolean preserve = parent.getSelectedTable().filter((t) -> t == lists.get(from).table).isPresent() &&
+                               moves.entrySet().stream().allMatch((e) -> lists.get(from).current.getEntry(e.getKey()).count() == e.getValue());
             if (!lists.get(from).current.removeAll(moves).equals(moves))
                 throw new CardException(moves.keySet(), "error moving cards from list " + from);
             if (!lists.get(to).current.addAll(moves))
                 throw new CardException(moves.keySet(), "could not move cards to list " + to);
+            if (preserve)
+                parent.setSelectedComponents(lists.get(to).table, lists.get(to).current);
             updateTables(selected);
+            if (preserve)
+                lists.get(to).table.scrollRectToVisible(lists.get(to).table.getCellRect(lists.get(to).table.getSelectedRow(), 0, true));
             return true;
         }, () -> {
             var selected = parent.getSelectedCards();
+            boolean preserve = parent.getSelectedTable().filter((t) -> t == lists.get(to).table).isPresent() &&
+                               moves.entrySet().stream().allMatch((e) -> lists.get(to).current.getEntry(e.getKey()).count() == e.getValue());
             if (!lists.get(from).current.addAll(moves))
                 throw new CardException(moves.keySet(), "could not undo move from list " + from);
             if (!lists.get(to).current.removeAll(moves).equals(moves))
                 throw new CardException(moves.keySet(), "error undoing move to list " + to);
+            if (preserve)
+                parent.setSelectedComponents(lists.get(from).table, lists.get(from).current);
             updateTables(selected);
+            if (preserve)
+                lists.get(from).table.scrollRectToVisible(lists.get(from).table.getCellRect(lists.get(from).table.getSelectedRow(), 0, true));
             return true;
         });
     }


### PR DESCRIPTION
Preserve selection when moving cards between lists in a deck.  If all of the cards selected are moved (e.g. because the number moved is less than the number available in the source list), then the selection will move with them.  If some of the moved cards remain, then those will stay selected and the selection will not be moved to the target list.